### PR TITLE
[messaging] : deleteToken no need to parameters

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1225,7 +1225,7 @@ declare module 'react-native-firebase' {
          */
         getToken(): Promise<string>;
 
-        deleteToken(authorizedEntity?: string, scope?: string): Promise<void>;
+        deleteToken(): Promise<void>;
 
         /**
          * On a new message,


### PR DESCRIPTION
### Summary
Fixed mismatch in index.d.ts, deleteToken function have parameters only in InstanceId

### Checklist
- [O] Typescript updated

### Test Plan
No need to test ([Android](https://github.com/invertase/react-native-firebase/blob/4df26f44b03591aaa69760ec0fca50b9ae0414ea/android/src/main/java/io/invertase/firebase/messaging/RNFirebaseMessaging.java#L71) / [iOS](https://github.com/invertase/react-native-firebase/blob/4df26f44b03591aaa69760ec0fca50b9ae0414ea/ios/RNFirebase/messaging/RNFirebaseMessaging.m#L129))
```
  @ReactMethod
  public void getToken(Promise promise) {
    try {
      String senderId = FirebaseApp.getInstance().getOptions().getGcmSenderId();
      String token = FirebaseInstanceId
        .getInstance()
        .getToken(senderId, FirebaseMessaging.INSTANCE_ID_SCOPE);
      promise.resolve(token);
    } catch (Throwable e) {
      e.printStackTrace();
      promise.reject("messaging/fcm-token-error", e.getMessage());
    }
  }

  @ReactMethod
  public void deleteToken(Promise promise) {
    try {
      String senderId = FirebaseApp.getInstance().getOptions().getGcmSenderId();
      FirebaseInstanceId.getInstance().deleteToken(senderId, FirebaseMessaging.INSTANCE_ID_SCOPE);
      promise.resolve(null);
    } catch (Throwable e) {
      e.printStackTrace();
      promise.reject("messaging/fcm-token-error", e.getMessage());
    }
  }
```

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

 [GENERAL] [MINOR] [MESSAGING] - fixed mismatch params in index.d.ts

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
